### PR TITLE
docs: Badge Image Sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/badges/badging.png" height="50%" width="50%">
+<img src=assets/badges/badging.png height=72 />
 
 # Docs-Diversity-Inclusion-Badging
 
@@ -19,14 +19,12 @@ Here are the primary deliverables of the Diversity & Inclusion Badging Program:
 
 Four statuses exist for the Diversity and Inclusion Badging Program:
 
-  * Not Passing
-    * <img src="assets/badges/nopass.png" height="15%" width="15%">
-  * Passing 
-    * <img src="assets/badges/passing.png" height="15%" width="15%">
-  * Silver 
-    * <img src="assets/badges/silver.png" height="15%" width="15%">
-  * gold
-    * <img src="assets/badges/gold.png" height="15%" width="15%">
+| Level        | Badge
+|--------------|---------------------------------------------------
+| Not Passing  | <img src=assets/badges/nopass.png height=18 />
+| Passing      | <img src=assets/badges/passing.png height=18 />
+| Silver       | <img src=assets/badges/silver.png height=18 />
+| Gold         | <img src=assets/badges/gold.png height=18 />
 
 Each badge is made for an event or a project.
 


### PR DESCRIPTION
This PR rewrites `img` tags in the README to use `px`-based `height`-only attributes, and rely on web specs defaulting to the implicit `width=auto` in order to preserve aspect ratios.

> **Note** — Using `px` units defines the absolute size for the 100% zoom level, it does not prevent scaling when zooming (ie accessible and responsive).